### PR TITLE
Fix compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ project(VEZ VERSION 1.1.0 LANGUAGES CXX)
 
 find_package(Vulkan REQUIRED)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
 
 option(VEZ_COMPILE_SAMPLES "Compile sample demos" ON)

--- a/Source/Core/Device.cpp
+++ b/Source/Core/Device.cpp
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
+#include <cmath>
 #include <iostream>
 #include <array>
 #include <unordered_map>


### PR DESCRIPTION
I don't know if you accept pull requests and you don't have a license for this project, so in case you need legal assurance I release these two very minor fixes under public domain :)

This contains two compilation fixes:

```
[ 70%] Building CXX object Source/CMakeFiles/VEZ.dir/VEZ_ext.cpp.o
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp: In member function ‘VkResult vez::Device::BufferSubData(vez::Buffer*, VkDeviceSize, VkDeviceSize, const void*)’:
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp:393:70: error: ‘ceil’ is not a member of ‘std’
             auto alignedBytesToCopy = static_cast<VkDeviceSize>(std::ceil(bytesToCopy / static_cast<float>(alignedFlushSize))) * alignedFlushSize;
                                                                      ^~~~
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp:393:70: note: suggested alternative: ‘cerr’
             auto alignedBytesToCopy = static_cast<VkDeviceSize>(std::ceil(bytesToCopy / static_cast<float>(alignedFlushSize))) * alignedFlushSize;
                                                                      ^~~~
                                                                      cerr
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp: In member function ‘VkResult vez::Device::UncompressedImageSubData(vez::Image*, const VezImageSubDataInfo*, const void*)’:
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp:816:82: error: ‘ceil’ is not a member of ‘std’
                         auto alignedBytesToCopy = static_cast<VkDeviceSize>(std::ceil(bytesCopied / static_cast<float>(alignedFlushSize))) * alignedFlushSize;
                                                                                  ^~~~
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp:816:82: note: suggested alternative: ‘cerr’
                         auto alignedBytesToCopy = static_cast<VkDeviceSize>(std::ceil(bytesCopied / static_cast<float>(alignedFlushSize))) * alignedFlushSize;
                                                                                  ^~~~
                                                                                  cerr
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp: In member function ‘VkResult vez::Device::CompressedImageSubData(vez::Image*, const VezImageSubDataInfo*, const void*)’:
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp:956:82: error: ‘ceil’ is not a member of ‘std’
                         auto alignedBytesToCopy = static_cast<VkDeviceSize>(std::ceil(bytesCopied / static_cast<float>(alignedFlushSize))) * alignedFlushSize;
                                                                                  ^~~~
/home/ccoors/dev/V-EZ/Source/Core/Device.cpp:956:82: note: suggested alternative: ‘cerr’
                         auto alignedBytesToCopy = static_cast<VkDeviceSize>(std::ceil(bytesCopied / static_cast<float>(alignedFlushSize))) * alignedFlushSize;
                                                                                  ^~~~
                                                                                  cerr
```

and the second one:

```
[ 44%] Linking CXX shared library ../../Bin/x86_64/libVEZ.so
/usr/bin/ld: ../../Bin/x86_64/libspirv-cross-core.a(spirv_cross.cpp.o): relocation R_X86_64_PC32 against symbol `_ZN11spirv_cross13CompilerErrorD1Ev' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```