### PR TITLE
Fix hash calculation for descriptor set layouts caching.

### DIFF
--- a/Source/Core/DescriptorSetLayoutCache.cpp
+++ b/Source/Core/DescriptorSetLayoutCache.cpp
@@ -48,6 +48,8 @@ namespace vez
             bitfield->descriptorType = setResources[i].resourceType;
             bitfield->descriptorCount = setResources[i].arraySize;
             bitfield->stageFlags = setResources[i].stages;
+            
+            ++bitfield;
         }
 
         return hash;


### PR DESCRIPTION
The "hash" (if anything, it'd rather be a key) calculated for caching descriptor set layouts only considers the last resource of the selected set.

On an unrelated note, I don't like the usage of bitfields here; `DescriptorSetLayoutBindingBitField` without being packed already fits in a 64-bit register anyways.

Maybe consider specializing `std::hash` to make this code less, uh, .... weird.

Note that even with the proposed fix this is still very weird, as you are basically reinterpreting a `vector<i32>` as a `vector<i64>` where size is divided by two, yet you don't account for that when allocating the vector.