### PR TITLE
Fix a number of memory leaks

### DIFF
--- a/Source/Core/Device.cpp
+++ b/Source/Core/Device.cpp
@@ -729,6 +729,15 @@ namespace vez
         if (m_renderPassCache)
             delete m_renderPassCache;
 
+        // Destroy queues
+        for (auto& family : m_queues)
+        {
+            for (auto queue : family)
+            {
+                delete queue;
+            }
+        }
+
         // Destroy per queue command pools.
         for (auto it : m_commandPools)
         {

--- a/Source/Core/Instance.cpp
+++ b/Source/Core/Instance.cpp
@@ -78,8 +78,7 @@ namespace vez
             // Wrap native Vulkan handles in PhysicalDevice class.
             for (auto& pd : physicalDevices)
             {
-                auto pdImpl = new PhysicalDevice(instance, pd);
-                instance->m_physicalDevices.push_back(pdImpl);
+                instance->m_physicalDevices.emplace_back(instance, pd);
             }
         }
 

--- a/Source/Core/Instance.cpp
+++ b/Source/Core/Instance.cpp
@@ -97,5 +97,6 @@ namespace vez
     {
         delete pInstance->m_threadPool;
         vkDestroyInstance(pInstance->GetHandle(), nullptr);
+        delete pInstance;
     }
 }

--- a/Source/Core/Instance.h
+++ b/Source/Core/Instance.h
@@ -38,14 +38,14 @@ namespace vez
 
         VkInstance GetHandle() const { return m_handle; }
 
-        const std::vector<PhysicalDevice*>& GetPhysicalDevices() { return m_physicalDevices; }
+        std::vector<PhysicalDevice>& GetPhysicalDevices() { return m_physicalDevices; }
 
         ThreadPool* GetThreadPool() { return m_threadPool; }
 
     private:
         VkInstance m_handle = VK_NULL_HANDLE;
         std::vector<std::string> m_validationLayers;
-        std::vector<PhysicalDevice*> m_physicalDevices;
+        std::vector<PhysicalDevice> m_physicalDevices;
         ThreadPool* m_threadPool = nullptr;
     };    
 }

--- a/Source/Core/Pipeline.cpp
+++ b/Source/Core/Pipeline.cpp
@@ -235,6 +235,10 @@ namespace vez
 
     Pipeline::~Pipeline()
     {
+        // Remove all associated Vulkan pipelines from the pipeline cache
+        for (auto hash : m_associatedHashes)
+            m_device->GetPipelineCache()->EraseHash(hash);
+
         // Destroy pipeline layout.
         if (m_pipelineLayout != VK_NULL_HANDLE)
             vkDestroyPipelineLayout(m_device->GetHandle(), m_pipelineLayout, nullptr);
@@ -247,7 +251,13 @@ namespace vez
     VkPipeline Pipeline::GetHandle(const RenderPass* pRenderPass, const GraphicsState* pState)
     {
         VkPipeline handle = VK_NULL_HANDLE;
-        m_device->GetPipelineCache()->GetHandle(this, pRenderPass, pState, &handle);
+        auto result = m_device->GetPipelineCache()->GetHandle(this, pRenderPass, pState, &handle);
+
+        if (result.first == VK_SUCCESS && !result.second.empty())
+        {
+            m_associatedHashes.emplace_back(result.second);
+        }
+
         return handle;
     }
 

--- a/Source/Core/Pipeline.h
+++ b/Source/Core/Pipeline.h
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include "VEZ.h"
 #include "GraphicsState.h"
+#include "PipelineCache.h"
 
 namespace vez
 {
@@ -91,6 +92,7 @@ namespace vez
         std::unordered_map<uint32_t, std::vector<VezPipelineResource>> m_bindings;
         std::unordered_map<uint32_t, DescriptorSetLayout*> m_descriptorSetLayouts;
         std::unordered_map<uint64_t, VkAccessFlags> m_bindingAccessFlags;
+        std::vector<PipelineCache::PipelinePermutationHash> m_associatedHashes;
         
         VkPipelineLayout m_pipelineLayout = VK_NULL_HANDLE;
         

--- a/Source/Core/PipelineCache.h
+++ b/Source/Core/PipelineCache.h
@@ -37,14 +37,16 @@ namespace vez
     class PipelineCache
     {
     public:
+        using PipelinePermutationHash = std::vector<uint64_t>;
+
         PipelineCache(Device* device);
 
         ~PipelineCache();
 
-        VkResult GetHandle(const Pipeline* pipeline, const RenderPass* pRenderPass, const GraphicsState* pState, VkPipeline* pHandle);
+        std::pair<VkResult, PipelinePermutationHash> GetHandle(const Pipeline* pipeline, const RenderPass* pRenderPass, const GraphicsState* pState, VkPipeline* pHandle);
+        void EraseHash(PipelinePermutationHash hash);
 
     private:
-        typedef std::vector<uint64_t> PipelinePermutationHash;
 
         VkResult CreateGraphicsPipeline(const Pipeline* pipeline, const RenderPass* pRenderPass, const GraphicsState* pState, VkPipeline* pHandle);
 

--- a/Source/Core/Queue.cpp
+++ b/Source/Core/Queue.cpp
@@ -43,6 +43,16 @@ namespace vez
 
     }
 
+    Queue::~Queue()
+    {
+        while (!m_presentCmdBuffers.empty())
+        {
+            auto commandBuffer = std::get<0>(m_presentCmdBuffers.front());
+            m_device->FreeCommandBuffers(1, &commandBuffer);
+            m_presentCmdBuffers.pop();
+        }
+    }
+
     VkResult Queue::Submit(uint32_t submitCount, const VezSubmitInfo* pSubmits, VkFence* pFence)
     {
         // Create a fence for the submission if calling application requests one.

--- a/Source/Core/Queue.h
+++ b/Source/Core/Queue.h
@@ -35,6 +35,9 @@ namespace vez
     {
     public:
         Queue(Device* device, VkQueue queue, uint32_t queueFamilyIndex, uint32_t index, const VkQueueFamilyProperties& propertiesd);
+        Queue(const Queue&) = delete;
+        Queue& operator=(const Queue&) = delete;
+        ~Queue();
 
         Device* GetDevice() const { return m_device; }
 

--- a/Source/Core/StreamEncoder.cpp
+++ b/Source/Core/StreamEncoder.cpp
@@ -319,8 +319,8 @@ namespace vez
             auto stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
             if (IsDepthStencilFormat(imageView->GetFormat()))
             {
-                auto access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-                auto stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+                access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+                stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
             }
 
             m_pipelineBarriers.ImageAccess(endStreamPos + 1ULL, image, &subresourceRange, attachment.finalLayout, access, stage);

--- a/Source/Core/Swapchain.cpp
+++ b/Source/Core/Swapchain.cpp
@@ -146,6 +146,14 @@ namespace vez
 
     Swapchain::~Swapchain()
     {
+        FreeResources();
+
+        for (auto image : m_images)
+        {
+            delete image;
+            m_images.clear();
+        }
+
         if (m_handle)
             vkDestroySwapchainKHR(m_device->GetHandle(), m_handle, nullptr);
     }

--- a/Source/VEZ.cpp
+++ b/Source/VEZ.cpp
@@ -308,13 +308,8 @@ VkResult VKAPI_CALL vezCreateSwapchain(VkDevice device, const VezSwapchainCreate
 
 void VKAPI_CALL vezDestroySwapchain(VkDevice device, VezSwapchain swapchain)
 {
-    // Lookup object handle.
-    auto deviceImpl = vez::ObjectLookup::GetObjectImpl(device);
-    if (deviceImpl)
-    {
-        // Destroy swapchain.
-        delete reinterpret_cast<vez::Swapchain*>(swapchain);
-    }
+    // Destroy swapchain.
+    delete reinterpret_cast<vez::Swapchain*>(swapchain);
 }
 
 void VKAPI_CALL vezGetSwapchainSurfaceFormat(VezSwapchain swapchain, VkSurfaceFormatKHR* pFormat)

--- a/Source/VEZ.cpp
+++ b/Source/VEZ.cpp
@@ -77,9 +77,9 @@ VkResult VKAPI_CALL vezCreateInstance(const VezInstanceCreateInfo* pCreateInfo, 
     vez::ObjectLookup::AddObjectImpl(*pInstance, instanceImpl);
 
     // Add all of the instance's physical devices to ObjectLookup.
-    const auto& physicalDevices = instanceImpl->GetPhysicalDevices();
-    for (auto pd : physicalDevices)
-        vez::ObjectLookup::AddObjectImpl(pd->GetHandle(), pd);
+    auto& physicalDevices = instanceImpl->GetPhysicalDevices();
+    for (auto& pd : physicalDevices)
+        vez::ObjectLookup::AddObjectImpl(pd.GetHandle(), &pd);
 
     // Return success.
     return VK_SUCCESS;
@@ -93,8 +93,8 @@ void VKAPI_CALL vezDestroyInstance(VkInstance instance)
     {
         // Remove instance's physical devices from ObjectLookup.
         const auto& physicalDevices = instanceImpl->GetPhysicalDevices();
-        for (auto pd : physicalDevices)
-            vez::ObjectLookup::RemoveObjectImpl(pd->GetHandle());
+        for (auto& pd : physicalDevices)
+            vez::ObjectLookup::RemoveObjectImpl(pd.GetHandle());
 
         // Destroy Instance object and remove from ObjectLookup.
         vez::Instance::Destroy(instanceImpl);
@@ -118,7 +118,7 @@ VkResult VKAPI_CALL vezEnumeratePhysicalDevices(VkInstance instance, uint32_t* p
         {
             for (auto i = 0U; i < *pPhysicalDeviceCount; ++i)
             {
-                pPhysicalDevices[i] = physicalDevices[i]->GetHandle();
+                pPhysicalDevices[i] = physicalDevices[i].GetHandle();
             }
         }
     }


### PR DESCRIPTION
I've been running with address sanitizers on and a clean exit is something the library struggles with (you'll get pages of indirect leaks on exit). Aside from being bad for certain workloads where devices may be dynamically spun up or removed, this makes it difficult to analyze cases of indirect leaks outside of this library.

I believe I found most of them in this PR. The one API change I opted to make isn't user facing and just avoids a loose allocation per PhysicalDevice associated with the Instance. I had to relax the const-ness of the vector due to C++'s const behavior, but I think it's worth it in this case to avoid both the leak and the allocation.