### PR TITLE
Find and use ccache if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@
 cmake_minimum_required(VERSION 3.8)
 project(VEZ VERSION 1.1.0 LANGUAGES CXX)
 
+# Configure CCache if available
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
+
 find_package(Vulkan REQUIRED)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
`
ccache is a compiler cache. It speeds up recompilation by caching previous compilations and detecting when the same compilation is being done again.
`

This PR speeds up re-building