### PR TITLE
fix compile error when using new version glslang and spirv-cross

### DIFF
--- a/Source/Compiler/ResourceLimits.cpp
+++ b/Source/Compiler/ResourceLimits.cpp
@@ -125,17 +125,28 @@ const TBuiltInResource DefaultTBuiltInResource = {
     /* .MaxCullDistances = */ 8,
     /* .MaxCombinedClipAndCullDistances = */ 8,
     /* .MaxSamples = */ 4,
-    /* .limits = */ {
-        /* .nonInductiveForLoops = */ 1,
-        /* .whileLoops = */ 1,
-        /* .doWhileLoops = */ 1,
-        /* .generalUniformIndexing = */ 1,
-        /* .generalAttributeMatrixVectorIndexing = */ 1,
-        /* .generalVaryingIndexing = */ 1,
-        /* .generalSamplerIndexing = */ 1,
-        /* .generalVariableIndexing = */ 1,
-        /* .generalConstantMatrixVectorIndexing = */ 1,
-    }};
+	/* .MaxMeshOutputVerticesNV*/ 256,
+	/* .MaxMeshOutputPrimitivesNV*/ 512,
+	/* .MaxMeshWorkGroupSizeX_NV*/ 32,
+	/* .MaxMeshWorkGroupSizeY_NV*/ 1,
+	/* .MaxMeshWorkGroupSizeZ_NV*/ 1,
+	/* .MaxTaskWorkGroupSizeX_NV*/ 32,
+	/* .MaxTaskWorkGroupSizeY_NV*/ 1,
+	/* .MaxTaskWorkGroupSizeZ_NV*/ 1,
+	/* .MaxMeshViewCountNV*/ 4,
+	/* .limits = */
+	{
+		/* .nonInductiveForLoops = */ 1,
+		/* .whileLoops = */ 1,
+		/* .doWhileLoops = */ 1,
+		/* .generalUniformIndexing = */ 1,
+		/* .generalAttributeMatrixVectorIndexing = */ 1,
+		/* .generalVaryingIndexing = */ 1,
+		/* .generalSamplerIndexing = */ 1,
+		/* .generalVariableIndexing = */ 1,
+		/* .generalConstantMatrixVectorIndexing = */ 1,
+	} 
+};
 
 std::string GetDefaultTBuiltInResourceString()
 {

--- a/Source/Compiler/SPIRVReflection.cpp
+++ b/Source/Compiler/SPIRVReflection.cpp
@@ -106,7 +106,7 @@ namespace vez
             for (auto i = 0U; i < type.member_types.size(); ++i)
                 all_members_flag_mask.merge_and(get_member_decoration_bitset(type.self, i));
             
-            auto base_flags = meta[type.self].decoration.decoration_flags;
+            auto base_flags = ir.meta[type.self].decoration.decoration_flags;
             base_flags.merge_or(spirv_cross::Bitset(all_members_flag_mask));
 
             VkAccessFlags access = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;


### PR DESCRIPTION
See the detail :
[SPRIV-Cross change commit](https://github.com/KhronosGroup/SPIRV-Cross/commit/5bcf02f7c940ce98c86bedf265589722cedd58ed#diff-64677986f8e5c086b79bd23ffaf238c6)
[glslang change commit](https://github.com/KhronosGroup/glslang/commit/1f60c72c674d6a77043d03843563b4be63e80267#diff-d305665e5f6d0d268976041adacb5e72)